### PR TITLE
feat: integrate OpenAI support with model configuration and authentic…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2343,6 +2343,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
@@ -2850,6 +2860,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -2922,6 +2944,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -3230,6 +3264,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/atomically": {
       "version": "2.0.3",
@@ -3787,6 +3827,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/command-exists": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
@@ -4190,6 +4242,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -4557,7 +4618,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5049,6 +5109,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -5360,6 +5429,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
       }
     },
     "node_modules/forwarded": {
@@ -5788,7 +5892,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -5938,6 +6041,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/hyperdyperid": {
@@ -7659,6 +7771,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -10705,6 +10837,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -11392,6 +11533,7 @@
         "ignore": "^7.0.0",
         "micromatch": "^4.0.8",
         "open": "^10.1.2",
+        "openai": "^4.76.0",
         "shell-quote": "^1.8.2",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
@@ -11411,12 +11553,57 @@
         "node": ">=18"
       }
     },
+    "packages/core/node_modules/@types/node": {
+      "version": "18.19.113",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.113.tgz",
+      "integrity": "sha512-TmSTE9vyebJ9vSEiU+P+0Sp4F5tMgjiEOZaQUW6wA3ODvi6uBgkHQ+EsIu0pbiKvf9QHEvyRCiaz03rV0b+IaA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "packages/core/node_modules/ignore": {
       "version": "7.0.5",
       "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
+    },
+    "packages/core/node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "packages/core/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "packages/core/node_modules/ws": {
       "version": "8.18.2",

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -35,5 +35,12 @@ export const validateAuthMethod = (authMethod: string): string | null => {
     return null;
   }
 
+  if (authMethod === AuthType.USE_OPENAI) {
+    if (!process.env.OPENAI_API_KEY) {
+      return 'OPENAI_API_KEY environment variable not found. Add that to your .env and try again, no reload needed!';
+    }
+    return null;
+  }
+
   return 'Invalid auth method selected.';
 };

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react';
+import { AuthType } from '@google/gemini-cli-core';
 import { Box, Text, useInput } from 'ink';
+import React, { useState } from 'react';
+import { validateAuthMethod } from '../../config/auth.js';
+import { LoadedSettings, SettingScope } from '../../config/settings.js';
 import { Colors } from '../colors.js';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
-import { LoadedSettings, SettingScope } from '../../config/settings.js';
-import { AuthType } from '@google/gemini-cli-core';
-import { validateAuthMethod } from '../../config/auth.js';
 
 interface AuthDialogProps {
   onSelect: (authMethod: string | undefined, scope: SettingScope) => void;
@@ -35,6 +35,7 @@ export function AuthDialog({
     },
     { label: 'Gemini API Key (AI Studio)', value: AuthType.USE_GEMINI },
     { label: 'Vertex AI', value: AuthType.USE_VERTEX_AI },
+    { label: 'OpenAI API Key', value: AuthType.USE_OPENAI },
   ];
 
   let initialAuthIndex = items.findIndex(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,7 @@
     "ignore": "^7.0.0",
     "micromatch": "^4.0.8",
     "open": "^10.1.2",
+    "openai": "^4.76.0",
     "shell-quote": "^1.8.2",
     "simple-git": "^3.28.0",
     "strip-ansi": "^7.1.0",

--- a/packages/core/src/adapters/adapter-factory.ts
+++ b/packages/core/src/adapters/adapter-factory.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ContentGenerator } from '../core/contentGenerator.js';
+import { OpenAIContentGenerator } from './openai-content-generator.js';
+
+/**
+ * LLM提供商枚举
+ */
+export enum LLMProvider {
+  GEMINI = 'gemini',
+  OPENAI = 'openai',
+  VERTEX_AI = 'vertex-ai',
+}
+
+/**
+ * 适配器配置接口
+ */
+export interface AdapterConfig {
+  provider: LLMProvider;
+  apiKey: string;
+  model: string;
+  embeddingModel?: string;
+  vertexai?: boolean;
+  baseUrl?: string;
+}
+
+/**
+ * 支持的模型映射
+ */
+export const SUPPORTED_MODELS = {
+  [LLMProvider.GEMINI]: [
+    'gemini-2.5-pro',
+    'gemini-2.5-flash',
+    'gemini-1.5-pro',
+    'gemini-1.5-flash',
+  ],
+  [LLMProvider.OPENAI]: [
+    'gpt-4',
+    'gpt-4-turbo',
+    'gpt-4o',
+    'gpt-4o-mini',
+    'gpt-3.5-turbo',
+  ],
+  [LLMProvider.VERTEX_AI]: [
+    'gemini-2.5-pro',
+    'gemini-2.5-flash',
+    'gemini-1.5-pro',
+    'gemini-1.5-flash',
+  ],
+};
+
+/**
+ * 默认嵌入模型映射
+ */
+export const DEFAULT_EMBEDDING_MODELS = {
+  [LLMProvider.GEMINI]: 'gemini-embedding-001',
+  [LLMProvider.OPENAI]: 'text-embedding-ada-002',
+  [LLMProvider.VERTEX_AI]: 'gemini-embedding-001',
+};
+
+/**
+ * 适配器工厂类
+ * 负责根据配置创建相应的LLM适配器
+ */
+export class AdapterFactory {
+  /**
+   * 创建LLM适配器
+   */
+  static createAdapter(config: AdapterConfig): ContentGenerator {
+    const { provider, apiKey, model, embeddingModel, vertexai, baseUrl } = config;
+
+    // 验证API密钥
+    if (!apiKey) {
+      throw new Error(`API key is required for ${provider} provider`);
+    }
+
+    // 验证模型是否支持
+    if (!this.isModelSupported(provider, model)) {
+      console.warn(`Model ${model} may not be officially supported for ${provider}`);
+    }
+
+    const effectiveEmbeddingModel = embeddingModel || DEFAULT_EMBEDDING_MODELS[provider];
+
+    switch (provider) {
+      case LLMProvider.OPENAI:
+        return new OpenAIContentGenerator(apiKey, model, effectiveEmbeddingModel);
+
+      default:
+        throw new Error(`Unsupported LLM provider: ${provider}`);
+    }
+  }
+
+  /**
+   * 检查模型是否受支持
+   */
+  static isModelSupported(provider: LLMProvider, model: string): boolean {
+    const supportedModels = SUPPORTED_MODELS[provider];
+    return supportedModels ? supportedModels.includes(model) : false;
+  }
+
+  /**
+   * 获取提供商的支持模型列表
+   */
+  static getSupportedModels(provider: LLMProvider): string[] {
+    return SUPPORTED_MODELS[provider] || [];
+  }
+
+  /**
+   * 从模型名称推断提供商
+   */
+  static inferProviderFromModel(model: string): LLMProvider | null {
+    for (const [provider, models] of Object.entries(SUPPORTED_MODELS)) {
+      if (models.includes(model)) {
+        return provider as LLMProvider;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * 获取所有支持的提供商
+   */
+  static getSupportedProviders(): LLMProvider[] {
+    return Object.values(LLMProvider);
+  }
+
+  /**
+   * 验证配置
+   */
+  static validateConfig(config: AdapterConfig): { valid: boolean; errors: string[] } {
+    const errors: string[] = [];
+
+    if (!config.provider) {
+      errors.push('Provider is required');
+    }
+
+    if (!config.apiKey) {
+      errors.push('API key is required');
+    }
+
+    if (!config.model) {
+      errors.push('Model is required');
+    }
+
+    if (config.provider && !this.getSupportedProviders().includes(config.provider)) {
+      errors.push(`Unsupported provider: ${config.provider}`);
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+    };
+  }
+} 

--- a/packages/core/src/adapters/adapter.test.ts
+++ b/packages/core/src/adapters/adapter.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { AdapterFactory, LLMProvider } from './adapter-factory.js';
+
+describe('AdapterFactory', () => {
+  describe('validateConfig', () => {
+    it('should validate valid OpenAI config', () => {
+      const config = {
+        provider: LLMProvider.OPENAI,
+        apiKey: 'sk-test-key',
+        model: 'gpt-4',
+      };
+
+      const result = AdapterFactory.validateConfig(config);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should validate valid Gemini config', () => {
+      const config = {
+        provider: LLMProvider.GEMINI,
+        apiKey: 'test-gemini-key',
+        model: 'gemini-2.5-pro',
+      };
+
+      const result = AdapterFactory.validateConfig(config);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should reject config without API key', () => {
+      const config = {
+        provider: LLMProvider.OPENAI,
+        apiKey: '',
+        model: 'gpt-4',
+      };
+
+      const result = AdapterFactory.validateConfig(config);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('API key is required');
+    });
+
+    it('should reject config without model', () => {
+      const config = {
+        provider: LLMProvider.OPENAI,
+        apiKey: 'sk-test-key',
+        model: '',
+      };
+
+      const result = AdapterFactory.validateConfig(config);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Model is required');
+    });
+  });
+
+  describe('isModelSupported', () => {
+    it('should return true for supported OpenAI models', () => {
+      expect(AdapterFactory.isModelSupported(LLMProvider.OPENAI, 'gpt-4')).toBe(true);
+      expect(AdapterFactory.isModelSupported(LLMProvider.OPENAI, 'gpt-4o')).toBe(true);
+    });
+
+    it('should return true for supported Gemini models', () => {
+      expect(AdapterFactory.isModelSupported(LLMProvider.GEMINI, 'gemini-2.5-pro')).toBe(true);
+      expect(AdapterFactory.isModelSupported(LLMProvider.GEMINI, 'gemini-2.5-flash')).toBe(true);
+    });
+
+    it('should return false for unsupported models', () => {
+      expect(AdapterFactory.isModelSupported(LLMProvider.OPENAI, 'unknown-model')).toBe(false);
+      expect(AdapterFactory.isModelSupported(LLMProvider.GEMINI, 'unknown-model')).toBe(false);
+    });
+  });
+
+  describe('inferProviderFromModel', () => {
+    it('should infer OpenAI provider from OpenAI models', () => {
+      expect(AdapterFactory.inferProviderFromModel('gpt-4')).toBe(LLMProvider.OPENAI);
+      expect(AdapterFactory.inferProviderFromModel('gpt-4o')).toBe(LLMProvider.OPENAI);
+    });
+
+    it('should infer Gemini provider from Gemini models', () => {
+      expect(AdapterFactory.inferProviderFromModel('gemini-2.5-pro')).toBe(LLMProvider.GEMINI);
+      expect(AdapterFactory.inferProviderFromModel('gemini-2.5-flash')).toBe(LLMProvider.GEMINI);
+    });
+
+    it('should return null for unknown models', () => {
+      expect(AdapterFactory.inferProviderFromModel('unknown-model')).toBe(null);
+    });
+  });
+
+  describe('getSupportedProviders', () => {
+    it('should return all supported providers', () => {
+      const providers = AdapterFactory.getSupportedProviders();
+      expect(providers).toContain(LLMProvider.GEMINI);
+      expect(providers).toContain(LLMProvider.OPENAI);
+      expect(providers).toContain(LLMProvider.VERTEX_AI);
+    });
+  });
+
+  describe('getSupportedModels', () => {
+    it('should return OpenAI models for OpenAI provider', () => {
+      const models = AdapterFactory.getSupportedModels(LLMProvider.OPENAI);
+      expect(models).toContain('gpt-4');
+      expect(models).toContain('gpt-4o');
+      expect(models).toContain('gpt-3.5-turbo');
+    });
+
+    it('should return Gemini models for Gemini provider', () => {
+      const models = AdapterFactory.getSupportedModels(LLMProvider.GEMINI);
+      expect(models).toContain('gemini-2.5-pro');
+      expect(models).toContain('gemini-2.5-flash');
+    });
+  });
+}); 

--- a/packages/core/src/adapters/index.ts
+++ b/packages/core/src/adapters/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export {
+    DEFAULT_EMBEDDING_MODELS, LLMProvider,
+    SUPPORTED_MODELS, type AdapterConfig
+} from './adapter-factory.js';
+export { OpenAIContentGenerator } from './openai-content-generator.js';
+export { createOpenAIContentGenerator } from './simple-factory.js';
+

--- a/packages/core/src/adapters/openai-content-generator.ts
+++ b/packages/core/src/adapters/openai-content-generator.ts
@@ -1,0 +1,359 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    Candidate,
+    ContentUnion,
+    CountTokensParameters,
+    CountTokensResponse,
+    EmbedContentParameters,
+    EmbedContentResponse,
+    GenerateContentParameters,
+    GenerateContentResponse,
+} from '@google/genai';
+import OpenAI from 'openai';
+import { ContentGenerator } from '../core/contentGenerator.js';
+
+/**
+ * OpenAI内容生成器
+ * 实现ContentGenerator接口，提供与OpenAI API的集成
+ */
+export class OpenAIContentGenerator implements ContentGenerator {
+  private client: OpenAI;
+  private model: string;
+  private embeddingModel: string;
+
+  constructor(
+    apiKey: string, 
+    model: string = 'gpt-4', 
+    embeddingModel: string = 'text-embedding-ada-002',
+    baseURL?: string
+  ) {
+    this.client = new OpenAI({
+      apiKey,
+      baseURL,
+    });
+    this.model = model;
+    this.embeddingModel = embeddingModel;
+  }
+
+  async generateContent(request: GenerateContentParameters): Promise<GenerateContentResponse> {
+    try {
+      const messages = this.convertToOpenAIMessages(request);
+      
+      const response = await this.client.chat.completions.create({
+        model: this.model,
+        messages,
+        stream: false,
+      });
+
+      return this.convertToGeminiResponse(response);
+    } catch (error) {
+      throw new Error(`OpenAI API调用失败: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  async generateContentStream(
+    request: GenerateContentParameters,
+  ): Promise<AsyncGenerator<GenerateContentResponse>> {
+    const self = this;
+    return (async function* (): AsyncGenerator<GenerateContentResponse> {
+      try {
+        const messages = self.convertToOpenAIMessages(request);
+        
+        const stream = await self.client.chat.completions.create({
+          model: self.model,
+          messages,
+          stream: true,
+        });
+
+        for await (const chunk of stream) {
+          if (chunk.choices && chunk.choices.length > 0) {
+            const choice = chunk.choices[0];
+            if (choice.delta?.content) {
+              yield self.convertStreamChunkToGeminiResponse(chunk);
+            }
+          }
+        }
+      } catch (error) {
+        throw new Error(`OpenAI流式API调用失败: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    })();
+  }
+
+  async countTokens(request: CountTokensParameters): Promise<CountTokensResponse> {
+    try {
+      // OpenAI没有直接的token计数API，我们使用简单的估算
+      const text = this.extractTextFromRequest(request);
+      const estimatedTokens = Math.ceil(text.length / 4); // 粗略估算
+
+      return {
+        totalTokens: estimatedTokens,
+      };
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  async embedContent(request: EmbedContentParameters): Promise<EmbedContentResponse> {
+    try {
+      const text = this.extractTextFromEmbedRequest(request);
+      
+      const response = await this.client.embeddings.create({
+        model: this.embeddingModel,
+        input: text,
+      });
+
+      return {
+        embeddings: [
+          {
+            values: response.data[0]?.embedding || []
+          }
+        ]
+      };
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /**
+   * 将Gemini格式的请求转换为OpenAI格式
+   */
+  private convertToOpenAIMessages(request: GenerateContentParameters): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
+    const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+
+    // 处理系统指令
+    if (request.config?.systemInstruction) {
+      const systemContent = this.extractTextFromContent(request.config.systemInstruction);
+      if (systemContent) {
+        messages.push({
+          role: 'system',
+          content: systemContent,
+        });
+      }
+    }
+
+    // 处理对话内容
+    if (Array.isArray(request.contents)) {
+      for (const content of request.contents) {
+        const text = this.extractTextFromContent(content);
+        const role = this.extractRoleFromContent(content);
+        if (text) {
+          messages.push({
+            role: role === 'model' ? 'assistant' : 'user',
+            content: text,
+          });
+        }
+      }
+    } else if (request.contents) {
+      const text = this.extractTextFromContent(request.contents);
+      const role = this.extractRoleFromContent(request.contents);
+      if (text) {
+        messages.push({
+          role: role === 'model' ? 'assistant' : 'user',
+          content: text,
+        });
+      }
+    }
+
+    return messages;
+  }
+
+  /**
+   * 从Content对象中提取文本
+   */
+  private extractTextFromContent(content: ContentUnion): string {
+    if (typeof content === 'string') {
+      return content;
+    }
+
+    if (Array.isArray(content)) {
+      return content
+        .map(part => this.extractTextFromPart(part))
+        .filter(text => text)
+        .join('');
+    }
+
+    if (content && typeof content === 'object' && 'parts' in content && Array.isArray(content.parts)) {
+      return content.parts
+        .map(part => this.extractTextFromPart(part))
+        .filter(text => text)
+        .join('');
+    }
+
+    return '';
+  }
+
+  /**
+   * 从Content对象中提取角色
+   */
+  private extractRoleFromContent(content: ContentUnion): string {
+    if (content && typeof content === 'object' && 'role' in content && typeof content.role === 'string') {
+      return content.role;
+    }
+    return 'user';
+  }
+
+  /**
+   * 从Part对象中提取文本
+   */
+  private extractTextFromPart(part: any): string {
+    if (typeof part === 'string') {
+      return part;
+    }
+    
+    if (part && typeof part === 'object') {
+      if (part.text && typeof part.text === 'string') {
+        return part.text;
+      }
+    }
+    
+    return '';
+  }
+
+  /**
+   * 将OpenAI响应转换为Gemini格式
+   */
+  private convertToGeminiResponse(response: OpenAI.Chat.Completions.ChatCompletion): GenerateContentResponse {
+    const choice = response.choices[0];
+    
+    const geminiResponse = new GenerateContentResponse();
+    
+    // 设置候选项
+    const candidate: Candidate = {
+      content: {
+        parts: [{ text: choice.message.content || '' }],
+        role: 'model'
+      },
+      finishReason: this.convertFinishReason(choice.finish_reason),
+      index: 0
+    };
+    
+    geminiResponse.candidates = [candidate];
+    
+    // 设置使用元数据
+    if (response.usage) {
+      geminiResponse.usageMetadata = {
+        promptTokenCount: response.usage.prompt_tokens,
+        candidatesTokenCount: response.usage.completion_tokens,
+        totalTokenCount: response.usage.total_tokens,
+      };
+    }
+    
+    return geminiResponse;
+  }
+
+  /**
+   * 将OpenAI流式响应块转换为Gemini格式
+   */
+  private convertStreamChunkToGeminiResponse(chunk: OpenAI.Chat.Completions.ChatCompletionChunk): GenerateContentResponse {
+    const choice = chunk.choices[0];
+    
+    const geminiResponse = new GenerateContentResponse();
+    
+    const candidate: Candidate = {
+      content: {
+        parts: [{ text: choice.delta?.content || '' }],
+        role: 'model'
+      },
+      finishReason: this.convertFinishReason(choice.finish_reason),
+      index: 0
+    };
+    
+    geminiResponse.candidates = [candidate];
+    
+    return geminiResponse;
+  }
+
+  /**
+   * 转换结束原因
+   */
+  private convertFinishReason(reason: string | null): any {
+    if (!reason) return undefined;
+    
+    switch (reason) {
+      case 'stop':
+        return 'STOP';
+      case 'length':
+        return 'MAX_TOKENS';
+      case 'content_filter':
+        return 'SAFETY';
+      default:
+        return 'OTHER';
+    }
+  }
+
+  /**
+   * 从请求中提取文本用于token计数
+   */
+  private extractTextFromRequest(request: CountTokensParameters): string {
+    let text = '';
+    
+    if (typeof request === 'object' && 'contents' in request) {
+      const contents = Array.isArray(request.contents) ? request.contents : [request.contents];
+      
+      for (const content of contents) {
+        if (typeof content === 'object' && 'parts' in content && content.parts) {
+          for (const part of content.parts) {
+            if (typeof part === 'object' && part && 'text' in part && part.text) {
+              text += part.text + ' ';
+            }
+          }
+        }
+      }
+    }
+    
+    return text;
+  }
+
+  /**
+   * 从嵌入请求中提取文本
+   */
+  private extractTextFromEmbedRequest(request: EmbedContentParameters): string {
+    if (typeof request === 'object' && 'contents' in request) {
+      const contents = Array.isArray(request.contents) ? request.contents : [request.contents];
+      
+      for (const content of contents) {
+        if (typeof content === 'object' && 'parts' in content && content.parts) {
+          for (const part of content.parts) {
+            if (typeof part === 'object' && part && 'text' in part && part.text) {
+              return part.text;
+            }
+          }
+        }
+      }
+    }
+    
+    return '';
+  }
+
+  /**
+   * 处理错误并转换为统一格式
+   */
+  private handleError(error: any): Error {
+    if (error instanceof OpenAI.APIError) {
+      return new Error(`OpenAI API Error: ${error.message} (${error.status})`);
+    }
+    
+    if (error instanceof Error) {
+      return error;
+    }
+
+    return new Error(`Unknown OpenAI error: ${String(error)}`);
+  }
+}
+
+/**
+ * 创建OpenAI内容生成器的工厂函数
+ */
+export function createOpenAIContentGenerator(
+  apiKey: string, 
+  model?: string, 
+  embeddingModel?: string,
+  baseURL?: string
+): OpenAIContentGenerator {
+  return new OpenAIContentGenerator(apiKey, model, embeddingModel, baseURL);
+} 

--- a/packages/core/src/adapters/simple-factory.ts
+++ b/packages/core/src/adapters/simple-factory.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ContentGenerator } from '../core/contentGenerator.js';
+import { OpenAIContentGenerator } from './openai-content-generator.js';
+
+/**
+ * 创建OpenAI内容生成器
+ */
+export function createOpenAIContentGenerator(
+  apiKey: string, 
+  model: string = 'gpt-4',
+  embeddingModel: string = 'text-embedding-ada-002',
+  baseURL?: string
+): ContentGenerator {
+  return new OpenAIContentGenerator(apiKey, model, embeddingModel, baseURL);
+} 

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -7,3 +7,15 @@
 export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
 export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
 export const DEFAULT_GEMINI_EMBEDDING_MODEL = 'gemini-embedding-001';
+
+// OpenAI模型配置
+export const DEFAULT_OPENAI_MODEL = 'gpt-4';
+export const DEFAULT_OPENAI_EMBEDDING_MODEL = 'text-embedding-ada-002';
+
+// 模型映射 - 根据认证类型确定默认模型
+export const DEFAULT_MODELS_BY_AUTH_TYPE = {
+  'oauth-personal': DEFAULT_GEMINI_MODEL,
+  'gemini-api-key': DEFAULT_GEMINI_MODEL,
+  'vertex-ai': DEFAULT_GEMINI_MODEL,
+  'openai-api-key': DEFAULT_OPENAI_MODEL,
+} as const;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,18 +6,19 @@
 
 // Export config
 export * from './config/config.js';
+export * from './config/models.js';
 
 // Export Core Logic
 export * from './core/client.js';
 export * from './core/contentGenerator.js';
+export * from './core/coreToolScheduler.js';
 export * from './core/geminiChat.js';
+export * from './core/geminiRequest.js';
 export * from './core/logger.js';
+export * from './core/nonInteractiveToolExecutor.js';
 export * from './core/prompts.js';
 export * from './core/tokenLimits.js';
 export * from './core/turn.js';
-export * from './core/geminiRequest.js';
-export * from './core/coreToolScheduler.js';
-export * from './core/nonInteractiveToolExecutor.js';
 
 export * from './code_assist/codeAssist.js';
 export * from './code_assist/oauth2.js';
@@ -25,37 +26,38 @@ export * from './code_assist/server.js';
 export * from './code_assist/types.js';
 
 // Export utilities
-export * from './utils/paths.js';
-export * from './utils/schemaValidator.js';
+export * from './utils/editor.js';
 export * from './utils/errors.js';
 export * from './utils/getFolderStructure.js';
-export * from './utils/memoryDiscovery.js';
 export * from './utils/gitIgnoreParser.js';
-export * from './utils/editor.js';
+export * from './utils/memoryDiscovery.js';
+export * from './utils/paths.js';
+export * from './utils/schemaValidator.js';
 
 // Export services
 export * from './services/fileDiscoveryService.js';
 export * from './services/gitService.js';
 
 // Export base tool definitions
-export * from './tools/tools.js';
 export * from './tools/tool-registry.js';
+export * from './tools/tools.js';
 
 // Export specific tool logic
-export * from './tools/read-file.js';
-export * from './tools/ls.js';
-export * from './tools/grep.js';
-export * from './tools/glob.js';
 export * from './tools/edit.js';
-export * from './tools/write-file.js';
-export * from './tools/web-fetch.js';
-export * from './tools/memoryTool.js';
-export * from './tools/shell.js';
-export * from './tools/web-search.js';
-export * from './tools/read-many-files.js';
+export * from './tools/glob.js';
+export * from './tools/grep.js';
+export * from './tools/ls.js';
 export * from './tools/mcp-client.js';
 export * from './tools/mcp-tool.js';
+export * from './tools/memoryTool.js';
+export * from './tools/read-file.js';
+export * from './tools/read-many-files.js';
+export * from './tools/shell.js';
+export * from './tools/web-fetch.js';
+export * from './tools/web-search.js';
+export * from './tools/write-file.js';
 
 // Export telemetry functions
 export * from './telemetry/index.js';
 export { sessionId } from './utils/session.js';
+


### PR DESCRIPTION
## TLDR

This PR adds comprehensive OpenAI API support to Gemini CLI, enabling users to switch between Gemini and OpenAI providers seamlessly. Users can configure multiple API keys in their `.env` file and dynamically switch between providers using the `/auth` command without restarting the CLI.

## Dive Deeper

### Core Changes

**1. Multi-LLM Architecture**
- Added `OpenAIContentGenerator` class implementing the `ContentGenerator` interface
- Created factory functions for OpenAI content generation with full configuration support
- Extended authentication system to support `AuthType.USE_OPENAI`

**2. Enhanced Configuration System**
- Extended `ContentGeneratorConfig` to support OpenAI-specific settings:
  - `OPENAI_API_KEY`: API authentication
  - `OPENAI_MODEL`: Conversation model (default: `gpt-4`)
  - `OPENAI_BASE_URL`: Custom API endpoints (supports Azure OpenAI, Ollama, LocalAI)
  - `OPENAI_EMBEDDING_MODEL`: Custom embedding model
- Updated CLI argument parsing to intelligently select default models based on selected auth type

**3. Dynamic Provider Switching**
- Modified `/auth` command to support runtime switching between providers
- Fixed About dialog (`/about`) to display correct model names based on selected authentication
- Users can configure multiple API keys simultaneously and switch without restart

**4. OpenAI-Compatible Services Support**
- Full support for Azure OpenAI Service
- Compatible with local inference servers (Ollama, LocalAI)
- Configurable base URLs for third-party OpenAI-compatible APIs

### Technical Implementation

**Authentication Flow**:
1. User configures API keys in `.env` file
2. CLI presents authentication options including "OpenAI API Key"
3. User selects provider via `/auth` command
4. System automatically uses appropriate model defaults and configuration

**Model Selection Logic**:
- OpenAI auth → Uses `OPENAI_MODEL` or defaults to `gpt-4`
- Gemini auth → Uses `GEMINI_MODEL` or defaults to `gemini-2.5-pro`
- About dialog correctly reflects the active provider's model

## Reviewer Test Plan

### Setup
1. Create `.env` file with both providers:
```env
GEMINI_API_KEY=your-gemini-key
OPENAI_API_KEY=your-openai-key
OPENAI_MODEL=gpt-4o
OPENAI_BASE_URL=https://api.openai.com/v1
```

### Test Scenarios

**Basic Provider Switching**:
1. Run `gemini` command
2. Select "OpenAI API Key" from auth dialog
3. Verify conversation works with OpenAI
4. Use `/auth` to switch to "Gemini API Key"
5. Verify conversation works with Gemini

**Model Configuration Validation**:
1. Configure `OPENAI_MODEL=gpt-4o` in `.env`
2. Select OpenAI authentication
3. Run `/about` command
4. Verify "Model" field shows `gpt-4o` (not `gemini-2.5-pro`)

**OpenAI-Compatible Services**:
1. Set `OPENAI_BASE_URL` to local Ollama instance
2. Test with local models via OpenAI-compatible endpoint

**Example Prompts**:
- "What's the weather like?" (test basic conversation)
- "/model gpt-3.5-turbo" (test model switching)
- "/about" (verify correct model display)
- Complex coding tasks to test different model capabilities

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ✅  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❌* | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

*Docker testing failed due to sandbox build issues (unrelated to OpenAI functionality)

### Verified Features
- ✅ OpenAI API authentication and conversation
- ✅ Dynamic provider switching via `/auth`
- ✅ Correct model display in `/about` dialog
- ✅ Environment variable configuration
- ✅ OpenAI base URL customization
- ✅ Model selection via `OPENAI_MODEL`

## Linked issues / bugs

- Addresses user request for multi-LLM provider support
- Fixes About dialog showing incorrect model names when using OpenAI
- Enables integration with OpenAI-compatible local inference servers